### PR TITLE
Add project scaffold script and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: setup train backtest full
+
+setup:
+	python scaffold.py
+
+train:
+	python pipelines/train_pipeline.py
+
+backtest:
+	python pipelines/backtest_pipeline.py
+
+full:
+	python pipelines/full_pipeline.py

--- a/README.md
+++ b/README.md
@@ -9,3 +9,20 @@ Medallion-style quant project.
 - pipelines/: scripts
 - notebooks/: Colab & Jupyter
 - logs/: run outputs
+
+## Getting Started
+
+Run the scaffold script to create the standard project structure and placeholder files:
+
+```bash
+python scaffold.py
+```
+
+Automation is available via the included Makefile:
+
+```bash
+make setup     # create folders and placeholder files
+make train     # run the training pipeline
+make backtest  # run the backtest pipeline
+make full      # run train and backtest sequentially
+```

--- a/scaffold.py
+++ b/scaffold.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+ROOT = Path(__file__).parent.resolve()
+
+DIRS = [
+    ROOT / "data" / "raw",
+    ROOT / "data" / "processed",
+    ROOT / "data" / "altdata",
+    ROOT / "models" / "trained",
+    ROOT / "models" / "hf" / "finbert",
+    ROOT / "models" / "hf" / "finbert-tone",
+    ROOT / "modules",
+    ROOT / "pipelines",
+    ROOT / "notebooks",
+    ROOT / "logs",
+]
+
+FILES = {
+    ROOT / "README.md": "# Quant Backtest ML\n\nMedallion-style quant project.\n",
+    ROOT / "requirements.txt": "\n".join([
+        "pandas",
+        "numpy",
+        "yfinance",
+        "scikit-learn",
+        "backtrader",
+        "ta",
+        "transformers",
+        "torch",
+        "joblib",
+    ]) + "\n",
+    ROOT / ".env_template": """# Copy to .env and fill your keys
+HUGGINGFACE_TOKEN=
+TIINGO_API_KEY=
+POLYGON_API_KEY=
+NEWSAPI_KEY=
+""",
+    ROOT / "config.yaml": (
+        "project_root: \"{root}\"\n"
+        "data:\n"
+        "  raw: \"data/raw\"\n"
+        "  processed: \"data/processed\"\n"
+        "  alt: \"data/altdata\"\n"
+        "models:\n"
+        "  hf:\n"
+        "    finbert: \"models/hf/finbert\"\n"
+        "    tone: \"models/hf/finbert-tone\"\n"
+        "  trained: \"models/trained\"\n"
+    ),
+    ROOT / "Dockerfile": """FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD [\"python\", \"main.py\"]
+""",
+}
+
+
+def write_file(path: Path, content: str) -> None:
+    if not path.exists():
+        path.write_text(content.format(root=ROOT.as_posix()))
+        print(f"Created {path.relative_to(ROOT)}")
+    else:
+        print(f"Exists  {path.relative_to(ROOT)}")
+
+
+def main() -> None:
+    for d in DIRS:
+        d.mkdir(parents=True, exist_ok=True)
+        print(f"Ensured {d.relative_to(ROOT)}")
+    for p, content in FILES.items():
+        write_file(p, content)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scaffold.py` to generate standard project structure and placeholder files
- introduce `Makefile` for running scaffold, training, backtest and full pipeline
- update README with instructions for running the scaffold and Makefile targets

## Testing
- `python -m py_compile scaffold.py pipelines/*.py modules/data_ingestion.py modules/feature_engineering.py modules/model_training.py modules/model_evaluation.py modules/sentiment_analysis.py`


------
https://chatgpt.com/codex/tasks/task_b_68bf5abc925c8329a51306c9f3927136